### PR TITLE
feat: add syscalls for aarch64 target

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -104,6 +104,10 @@ func UserSessionKeyring() (Keyring, error) {
 	return newKeyring(keySpecUserSessionKeyring)
 }
 
+func UserKeyring() (Keyring, error) {
+	return newKeyring(keySpecUserKeyring)
+}
+
 // Return the current group keyring.
 func GroupKeyring() (Keyring, error) {
 	return newKeyring(keySpecGroupKeyring)

--- a/sys_linux_arm64.go
+++ b/sys_linux_arm64.go
@@ -1,0 +1,7 @@
+package keyctl
+//taken from https://github.com/jsipprell/keyctl/pull/17
+const (
+	syscall_keyctl   uintptr = 219
+	syscall_add_key  uintptr = 217
+	syscall_setfsgid uintptr = 152
+)


### PR DESCRIPTION
Previously got `undefined: syscall_keyctl` errors when building project-machine/trust on an aarch64 platform. Adding aarch64 specific syscalls fixes this (along with another tweak to tpm2.go in trust). Fix obtained from[ this PR](https://github.com/jsipprell/keyctl/pull/17) on jsipprell's keyctl repo. 
Signed-off-by: Ashwin Gopalan <ashwin.gopalan02@gmail.com>